### PR TITLE
Add checkpoint for PV restore

### DIFF
--- a/scripts/verify.sh
+++ b/scripts/verify.sh
@@ -30,6 +30,23 @@ fi
 echo $STATUS
 if [ "$STATUS" = 'success' ]
 then
+    nodes=`etcdctl get /kibishii/nodes/ --prefix --endpoints=http://etcd-client:2379 | grep ^kibishii-deployment`
+    for node in $nodes
+    do
+         results=`etcdctl get /kibishii/results/$OPID/$node --endpoints=http://etcd-client:2379 --print-value-only | jq ".missingDirs,.missingFiles"`
+         for result in $results
+         do
+            if [ -z $result ]; then
+                exit 2
+            fi
+            if [ "$result" !=  '0' ]; then
+                exit $result
+            fi
+        done
+    done
 	exit 0
 fi
+
 exit 1
+
+


### PR DESCRIPTION
In kibishii verify test step, no checkpoint for missing dirs and files which were genarated by kibishii, so if PV restore failed, kibishii  will still pass the test.
In this PR, a checkpoint was added to check if there are no missing dirs and files.

Signed-off-by: danfengl <danfengl@vmware.com>

