### PR TITLE
Modify volumeBindingMode to WaitForFirstConsumer  for Kibishii storage class

### DIFF
--- a/kubernetes/yaml/azure/kibishiiAzureStorageClass.yaml
+++ b/kubernetes/yaml/azure/kibishiiAzureStorageClass.yaml
@@ -8,5 +8,5 @@ parameters:
   kind: Managed
   storageaccounttype: StandardSSD_LRS
 reclaimPolicy: Delete
-volumeBindingMode: Immediate
+volumeBindingMode: WaitForFirstConsumer
 


### PR DESCRIPTION
Originally, volumeBindingMode is set as Immediate, in this case PV might be binding to a different zone from the zone which pod was in, so pod will be in pending state with log like this: Warning  FailedScheduling  2s (x8 over 1m)  default-scheduler  0/3 nodes are available: 1 node(s) had taints that the pod didn't tolerate, 2 node(s) had volume node affinity conflict.
According to the [description](https://kubernetes.io/docs/concepts/storage/storage-classes/#local
) , it should be set to WaitForFirstConsumer to binding dynamically.

Signed-off-by: danfengl <danfengl@vmware.com>