### PR TITLE
Remove pv related cr in etcd

### DIFF
--- a/kubernetes/yaml/base/etcd.yaml
+++ b/kubernetes/yaml/base/etcd.yaml
@@ -11,18 +11,6 @@ spec:
   selector:
     app: etcd
 
----
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: etcd0-pv-claim
-spec:
-  storageClassName: kibishii-storage-class
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
 
 ---
 
@@ -34,10 +22,6 @@ metadata:
     etcd_node: etcd0
   name: etcd0
 spec:
-  volumes:
-    - name: etcd0-storage
-      persistentVolumeClaim:
-       claimName: etcd0-pv-claim
   containers:
   - command:
     - /usr/local/bin/etcd
@@ -56,9 +40,6 @@ spec:
     - --initial-cluster-state
     - new
     image: quay.io/coreos/etcd:latest
-    volumeMounts:
-       - mountPath: "/etcd0.etcd"
-         name: etcd0-storage
     name: etcd0
     ports:
     - containerPort: 2379
@@ -90,19 +71,6 @@ spec:
   selector:
     etcd_node: etcd0
 
----
-
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: etcd1-pv-claim
-spec:
-  storageClassName: kibishii-storage-class
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
 
 ---
 
@@ -114,10 +82,6 @@ metadata:
     etcd_node: etcd1
   name: etcd1
 spec:
-  volumes:
-    - name: etcd1-storage
-      persistentVolumeClaim:
-       claimName: etcd1-pv-claim
   containers:
   - command:
     - /usr/local/bin/etcd
@@ -136,9 +100,6 @@ spec:
     - --initial-cluster-state
     - new
     image: quay.io/coreos/etcd:latest
-    volumeMounts:
-       - mountPath: "/etcd1.etcd"
-         name: etcd1-storage
     name: etcd1
     ports:
     - containerPort: 2379
@@ -172,19 +133,7 @@ spec:
 
 ---
 
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: etcd2-pv-claim
-spec:
-  storageClassName: kibishii-storage-class
-  accessModes:
-    - ReadWriteOnce
-  resources:
-    requests:
-      storage: 1Gi
 
----
 
 apiVersion: v1
 kind: Pod
@@ -194,10 +143,6 @@ metadata:
     etcd_node: etcd2
   name: etcd2
 spec:
-  volumes:
-    - name: etcd2-storage
-      persistentVolumeClaim:
-       claimName: etcd2-pv-claim
   containers:
   - command:
     - /usr/local/bin/etcd
@@ -216,9 +161,6 @@ spec:
     - --initial-cluster-state
     - new
     image: quay.io/coreos/etcd:latest
-    volumeMounts:
-       - mountPath: "/etcd2.etcd"
-         name: etcd2-storage
     name: etcd2
     ports:
     - containerPort: 2379


### PR DESCRIPTION
Etcd in kibishii is designed as a media to conmunication between kibishii worker and user, so data genarated by etcd should not be persistent, therefore etcd‘ pv should not be backed up and restored, then pv is not needed to etcd.

Signed-off-by: danfengl <danfengl@vmware.com>
