### PR TITLE
Update kibishii's images in docker hub to gcr

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ifndef VERSION
 VERSION := $(shell echo `git rev-parse --abbrev-ref HEAD`-`git log -1 --pretty=format:%h`-`date "+%d.%b.%Y.%H.%M.%S"`)
 endif
 
-REGISTRY ?= dpcpinternal
+REGISTRY ?= gcr.io/velero-gcp
 JUMP_PAD_IMAGE = $(REGISTRY)/jump-pad
 WORKER_IMAGE = $(REGISTRY)/kibishii-worker
 


### PR DESCRIPTION
Update kibishii images that are used by e2e test. Due to docker hub rate limitation, e2e test sometimes fails because of image pulling error, so update the images on docker hub to gcr.io to avoid this.

Signed-off-by: Xun Jiang <jxun@vmware.com>