### PR TITLE
Update the Kustomize files to ease the creation warnings.

### DIFF
--- a/kubernetes/yaml/aws-csi/kustomization.yaml
+++ b/kubernetes/yaml/aws-csi/kustomization.yaml
@@ -1,5 +1,5 @@
-bases:
-  - ../base
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
+  - ../base
   - kibishiiAWSCsiStorageClass.yaml

--- a/kubernetes/yaml/aws/kustomization.yaml
+++ b/kubernetes/yaml/aws/kustomization.yaml
@@ -1,5 +1,5 @@
-bases:
-  - ../base
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
+  - ../base
   - kibishiiAWSStorageClass.yaml

--- a/kubernetes/yaml/azure-csi/kustomization.yaml
+++ b/kubernetes/yaml/azure-csi/kustomization.yaml
@@ -1,5 +1,5 @@
-bases:
-  - ../base
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
+  - ../base
   - kibishiiAzureCsiStorageClass.yaml

--- a/kubernetes/yaml/azure/kustomization.yaml
+++ b/kubernetes/yaml/azure/kustomization.yaml
@@ -1,5 +1,5 @@
-bases:
-  - ../base
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
+  - ../base
   - kibishiiAzureStorageClass.yaml

--- a/kubernetes/yaml/gcp/kustomization.yaml
+++ b/kubernetes/yaml/gcp/kustomization.yaml
@@ -1,5 +1,5 @@
-bases:
-  - ../base
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
+  - ../base
   - kibishiiGCPStorageClass.yaml

--- a/kubernetes/yaml/kind/kustomization.yaml
+++ b/kubernetes/yaml/kind/kustomization.yaml
@@ -1,5 +1,5 @@
-bases:
-  - ../base
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
+  - ../base
   - kibishiiKINDStorageClass.yaml

--- a/kubernetes/yaml/vanilla-zfs/kustomization.yaml
+++ b/kubernetes/yaml/vanilla-zfs/kustomization.yaml
@@ -1,5 +1,5 @@
-bases:
-  - ../base
-
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
+  - ../base
   - kibishiiZFSStorageClass.yaml

--- a/kubernetes/yaml/vsphere/kustomization.yaml
+++ b/kubernetes/yaml/vsphere/kustomization.yaml
@@ -1,4 +1,5 @@
-bases:
-  - ../base
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
+  - ../base
   - kibishiiVKSStorageClass.yaml


### PR DESCRIPTION
The warning message is as following:
`Warning: 'bases' is deprecated. Please use 'resources' instead.`